### PR TITLE
Add basic game flow tests

### DIFF
--- a/Werwolf.Tests/GameManagerTests.cs
+++ b/Werwolf.Tests/GameManagerTests.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Werwolf.Data;
+using Werwolf.Data.Actions;
+using Werwolf.Workflow;
+
+namespace Werwolf.Tests;
+
+public class GameManagerTests
+{
+    public static IEnumerable<object[]> RoleInstances => new List<object[]>
+    {
+        new object[] { new AlteSchrulle() },
+        new object[] { new Amor() },
+        new object[] { new Doctor() },
+        new object[] { new Dorfbewohner() },
+        new object[] { new Grabrauber() },
+        new object[] { new Hexe() },
+        new object[] { new KittenWerwolf() },
+        new object[] { new Raecher() },
+        new object[] { new Seherin() },
+        new object[] { new Werwolf.Data.Werwolf() }
+    };
+
+    [Theory]
+    [MemberData(nameof(RoleInstances))]
+    public void Start_CreatesExpectedNumber(Role role)
+    {
+        role.Count = 2;
+        var players = role.Start();
+        Assert.Equal(2, players.Count);
+        Assert.All(players, p => Assert.Equal(role.RoleName, p.RoleName));
+    }
+
+    [Fact]
+    public void ProcessNight_KillHealedTarget_NoOneDies()
+    {
+        var gm = new GameManager();
+        gm.SetNames(new List<string> { "Wolf", "Doc", "Villager" });
+
+        var roles = new List<Role>
+        {
+            new Werwolf.Data.Werwolf { Count = 1 },
+            new Doctor { Count = 1 },
+            new Dorfbewohner { Count = 1 }
+        };
+
+        gm.StartGame(roles);
+
+        var wolf = gm.AllPlayers.First(p => p.RoleName == nameof(Werwolf.Data.Werwolf));
+        var doctor = gm.AllPlayers.First(p => p.RoleName == nameof(Doctor));
+        var villager = gm.AllPlayers.First(p => p.RoleName == nameof(Dorfbewohner));
+
+        wolf.DoAction(new List<string> { villager.PlayerName }, ActionType.Kill);
+        doctor.DoAction(new List<string> { villager.PlayerName }, ActionType.Heal);
+
+        gm.ProcessNight();
+
+        Assert.Empty(gm.DeadPlayers);
+        Assert.True(villager.IsAlive);
+    }
+
+    [Fact]
+    public void EndPlayerVote_EliminatesHighestVotedPlayer()
+    {
+        var gm = new GameManager();
+        gm.SetNames(new List<string> { "A", "B", "C" });
+
+        var roles = new List<Role>
+        {
+            new Dorfbewohner { Count = 3 }
+        };
+
+        gm.StartGame(roles);
+
+        var players = gm.AllPlayers.ToDictionary(p => p.PlayerName, p => p);
+
+        // two votes for player B, one vote for player C
+        gm.VotForVillagerElection(new List<RolePresentation>
+        {
+            RolePresentation.Clone(players["B"]),
+            RolePresentation.Clone(players["B"]),
+            RolePresentation.Clone(players["C"])
+        });
+
+        gm.EndPlayerVote();
+
+        Assert.Single(gm.DeadPlayers);
+        Assert.Equal("B", gm.DeadPlayers.First().PlayerName);
+    }
+}

--- a/Werwolf.Tests/Stubs/DeadPlayerPageType.cs
+++ b/Werwolf.Tests/Stubs/DeadPlayerPageType.cs
@@ -1,0 +1,9 @@
+namespace Werwolf.ViewModel
+{
+    public enum DeadPlayerPageType
+    {
+        None = 0,
+        DeadByNight = 1,
+        DeadByVoting = 2
+    }
+}

--- a/Werwolf.Tests/Stubs/MauiStubs.cs
+++ b/Werwolf.Tests/Stubs/MauiStubs.cs
@@ -1,0 +1,27 @@
+namespace Microsoft.Maui.Controls
+{
+    public class Shell
+    {
+        public static Shell Current { get; } = new Shell();
+        public System.Threading.Tasks.Task GoToAsync(string route) => System.Threading.Tasks.Task.CompletedTask;
+    }
+
+    public class ContentPage {}
+}
+
+namespace Werwolf
+{
+    public partial class NightBeginningPage : Microsoft.Maui.Controls.ContentPage {}
+    public partial class PlayerTurnMenuPage : Microsoft.Maui.Controls.ContentPage {}
+    public partial class PlayerTurnOverviewPage : Microsoft.Maui.Controls.ContentPage {}
+    public partial class DayBeginningPage : Microsoft.Maui.Controls.ContentPage {}
+    public partial class DayDeadPlayerPage : Microsoft.Maui.Controls.ContentPage {}
+    public partial class DiscussionPage : Microsoft.Maui.Controls.ContentPage {}
+    public partial class DiscussionTimerPage : Microsoft.Maui.Controls.ContentPage {}
+    public partial class GameOverPage : Microsoft.Maui.Controls.ContentPage {}
+    public partial class MainPage : Microsoft.Maui.Controls.ContentPage {}
+    public partial class RoleSelectionPage : Microsoft.Maui.Controls.ContentPage {}
+    public partial class SeherPage : Microsoft.Maui.Controls.ContentPage {}
+    public partial class SpecialPowerPage : Microsoft.Maui.Controls.ContentPage {}
+    public partial class VillagerVotingPage : Microsoft.Maui.Controls.ContentPage {}
+}

--- a/Werwolf.Tests/Werwolf.Tests.csproj
+++ b/Werwolf.Tests/Werwolf.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Werwolf\Data\**\*.cs" Link="Data\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\Werwolf\Workflow\*.cs" Link="Workflow\%(Filename)%(Extension)" />
+    <Compile Include="Stubs\DeadPlayerPageType.cs" />
+    <Compile Include="Stubs\MauiStubs.cs" />
+    <Compile Include="GameManagerTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Werwolf.sln
+++ b/Werwolf.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.11.35312.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Werwolf", "Werwolf\Werwolf.csproj", "{BDAF49F7-13FE-4588-9AE6-C17FFB9AD0F6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Werwolf.Tests", "Werwolf.Tests\Werwolf.Tests.csproj", "{CDFBC92F-03F1-4F78-A803-108E0C985886}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,6 +19,10 @@ Global
 		{BDAF49F7-13FE-4588-9AE6-C17FFB9AD0F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BDAF49F7-13FE-4588-9AE6-C17FFB9AD0F6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{BDAF49F7-13FE-4588-9AE6-C17FFB9AD0F6}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{CDFBC92F-03F1-4F78-A803-108E0C985886}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CDFBC92F-03F1-4F78-A803-108E0C985886}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CDFBC92F-03F1-4F78-A803-108E0C985886}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CDFBC92F-03F1-4F78-A803-108E0C985886}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Werwolf/Workflow/GameManager.cs
+++ b/Werwolf/Workflow/GameManager.cs
@@ -2,6 +2,7 @@
 using Werwolf.Data;
 using Werwolf.Data.Actions;
 using Werwolf.ViewModel;
+using Microsoft.Maui.Controls;
 
 namespace Werwolf.Workflow
 {


### PR DESCRIPTION
## Summary
- add xUnit test project with stubs for MAUI types
- cover role creation, night actions and village vote
- register new project in solution

## Testing
- `dotnet test Werwolf.Tests/Werwolf.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684339721850832695899de0bca4d807